### PR TITLE
Stop using deprecated increment/decrement operators

### DIFF
--- a/Sources/Core/Base64/Base64.swift
+++ b/Sources/Core/Base64/Base64.swift
@@ -57,7 +57,7 @@ private class Base64Encoder {
 
 	func encodeBlock() {
 		let fragment = bytes[offset]
-		offset++
+		offset += 1
 
 		switch step {
 		case .A:
@@ -76,7 +76,7 @@ private class Base64Encoder {
 			result  = (fragment & 0x03f) >> 0
 			output.append(encodeValue(result))
 			if let charsPerLine = self.charsPerLine {
-				stepcount++
+				stepcount += 1
 				if stepcount == charsPerLine/4 {
 					output.append(Base64Encoder.newlineChar)
 					stepcount = 0
@@ -142,7 +142,8 @@ private class Base64Decoder {
 		var tmpFragment: Int8
 		repeat {
 			guard offset < bytes.count else { return }
-			let byte = bytes[offset++]
+			let byte = bytes[offset]
+			offset += 1
 			tmpFragment = Base64Decoder.decodeValue(byte)
 		} while (tmpFragment < 0)
 		let fragment = UInt8(bitPattern: tmpFragment)
@@ -152,15 +153,18 @@ private class Base64Decoder {
 			output[outputOffset]	 = (fragment & 0x03f) << 2
 			step = .B
 		case .B:
-			output[outputOffset++]	|= (fragment & 0x030) >> 4
+			output[outputOffset]	|= (fragment & 0x030) >> 4
+			outputOffset += 1
 			output[outputOffset]	 = (fragment & 0x00f) << 4
 			step = .C
 		case .C:
-			output[outputOffset++]	|= (fragment & 0x03c) >> 2
+			output[outputOffset]	|= (fragment & 0x03c) >> 2
+			outputOffset += 1
 			output[outputOffset]	 = (fragment & 0x003) << 6
 			step = .D
 		case .D:
-			output[outputOffset++]	|= (fragment & 0x03f)
+			output[outputOffset]	|= (fragment & 0x03f)
+			outputOffset += 1
 			step = .A
 		}
 

--- a/Sources/Core/JSON/JSONParser.swift
+++ b/Sources/Core/JSON/JSONParser.swift
@@ -185,7 +185,7 @@ extension GenericJSONParser {
 
             while let d = hexToDigit(nextChar) {
                 advance()
-                length++
+                length += 1
 
                 if length > 8 {
                     break
@@ -246,7 +246,7 @@ extension GenericJSONParser {
                 if let value = digitToInt(currentChar) {
                     fraction += (Double(value) * factor)
                     factor /= 10
-                    fractionLength++
+                    fractionLength += 1
                 } else {
                     break
                 }
@@ -277,7 +277,7 @@ extension GenericJSONParser {
             while cur != end {
                 if let value = digitToInt(currentChar) {
                     exponent = (exponent * 10) + Int64(value)
-                    exponentLength++
+                    exponentLength += 1
                 } else {
                     break
                 }
@@ -423,17 +423,17 @@ extension GenericJSONParser {
     
     private func advance() {
         assert(cur != end, "out of range")
-        cur++
+        cur = cur.successor()
         
         if cur != end {
             switch currentChar {
                 
             case Char(ascii: "\n"):
-                lineNumber++
+                lineNumber += 1
                 columnNumber = 1
                 
             default:
-                columnNumber++
+                columnNumber += 1
             }
         }
     }

--- a/Sources/Core/JSON/JSONSerializer.swift
+++ b/Sources/Core/JSON/JSONSerializer.swift
@@ -70,9 +70,10 @@ public class DefaultJSONSerializer: JSONSerializer {
 
         for entry in o {
             s += "\(escapeAsJSONString(entry.0)):\(entry.1.serialize(self))"
-            if i++ != (o.count - 1) {
+            if i != (o.count - 1) {
                 s += ","
             }
+            i += 1
         }
 
         return s + "}"
@@ -84,7 +85,7 @@ public final class PrettyJSONSerializer: DefaultJSONSerializer {
 
     override public func serializeArray(a: [JSON]) -> String {
         var s = "["
-        indentLevel++
+        indentLevel += 1
 
         for i in 0 ..< a.count {
             s += "\n"
@@ -96,13 +97,13 @@ public final class PrettyJSONSerializer: DefaultJSONSerializer {
             }
         }
 
-        indentLevel--
+        indentLevel -= 1
         return s + "\n" + indent() + "]"
     }
 
     override public func serializeObject(o: [String: JSON]) -> String {
         var s = "{"
-        indentLevel++
+        indentLevel += 1
         var i = 0
 
         var keys = Array(o.keys)
@@ -113,12 +114,13 @@ public final class PrettyJSONSerializer: DefaultJSONSerializer {
             s += indent()
             s += "\(escapeAsJSONString(key)): \(o[key]!.serialize(self))"
 
-            if i++ != (o.count - 1) {
+            if i != (o.count - 1) {
                 s += ","
             }
+            i += 1
         }
 
-        indentLevel--
+        indentLevel -= 1
         return s + "\n" + indent() + "}"
     }
 

--- a/Sources/Core/String/String.swift
+++ b/Sources/Core/String/String.swift
@@ -51,11 +51,11 @@ extension String {
 
             case plusCharacter:
                 decodedData.append(spaceCharacter)
-                i++
+                i += 1
 
             default:
                 decodedData.append(currentCharacter)
-                i++
+                i += 1
             }
         }
 


### PR DESCRIPTION
Recent Swift compiler snapshots emit deprecation warnings for this.
